### PR TITLE
Ignore input events on fields that won't be saved

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -213,7 +213,7 @@ class OptionsSync<TOptions extends Options> {
 
 	private async _handleFormInput({target}: Event): Promise<void> {
 		const field = target as HTMLInputElement;
-		if (!target.name) {
+		if (!field.name) {
 			return;
 		}
 

--- a/index.ts
+++ b/index.ts
@@ -212,9 +212,13 @@ class OptionsSync<TOptions extends Options> {
 	}
 
 	private async _handleFormInput({target}: Event): Promise<void> {
-		const form = (target as HTMLInputElement).form!;
-		await this.set(this._parseForm(form));
-		form.dispatchEvent(new CustomEvent('options-sync:form-synced', {
+		const field = target as HTMLInputElement;
+		if (!target.name) {
+			return;
+		}
+
+		await this.set(this._parseForm(field.form!));
+		field.form!.dispatchEvent(new CustomEvent('options-sync:form-synced', {
 			bubbles: true
 		}));
 	}


### PR DESCRIPTION
Some forms include selectors and filters that won't be saved, so they should be ignored by the event handler as well.