### PR TITLE
Allow using `chrome.storage.local`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,8 @@ async function shouldRunMigrations(): Promise<boolean> {
 	});
 }
 
+export type StorageType = 'sync' | 'local' | 'managed';
+
 /**
 @example
 {
@@ -57,7 +59,7 @@ export interface Setup<UserOptions extends Options> {
 	 * A list of functions to call when the extension is updated.
 	 */
 	migrations?: Array<Migration<UserOptions>>;
-	storage?: chrome.storage.StorageArea;
+	storageType?: StorageType;
 }
 
 /**
@@ -106,11 +108,11 @@ class OptionsSync<UserOptions extends Options> {
 		storageName = 'options',
 		migrations = [],
 		logging = true,
-		storage = chrome.storage.sync,
+		storageType = 'sync',
 	}: Setup<UserOptions> = {}) {
 		this.storageName = storageName;
 		this.defaults = defaults;
-		this.storage = storage;
+		this.storage = chrome.storage[storageType];
 		this._handleFormInput = debounce(300, this._handleFormInput.bind(this));
 		this._handleStorageChangeOnForm = this._handleStorageChangeOnForm.bind(this);
 

--- a/index.ts
+++ b/index.ts
@@ -313,7 +313,8 @@ class OptionsSync<UserOptions extends Options> {
 	}
 
 	private _handleStorageChangeOnForm(changes: Record<string, any>, areaName: string): void {
-		if (areaName === this.storageType
+		if (
+			areaName === this.storageType
 			&& changes[this.storageName]
 			&& (!document.hasFocus() || !this._form!.contains(document.activeElement)) // Avoid applying changes while the user is editing a field
 		) {

--- a/package.json
+++ b/package.json
@@ -46,14 +46,15 @@
 		}
 	},
 	"dependencies": {
-		"webext-detect-page": "^4.0.0"
+		"@types/webextension-polyfill": "^0.8.3",
+		"webext-detect-page": "^4.0.0",
+		"webextension-polyfill": "^0.9.0"
 	},
 	"devDependencies": {
 		"@rollup/plugin-commonjs": "^21.0.1",
 		"@rollup/plugin-node-resolve": "^13.1.3",
 		"@rollup/plugin-typescript": "^8.3.0",
 		"@sindresorhus/tsconfig": "^2.0.0",
-		"@types/chrome": "0.0.176",
 		"@types/estree": "^0.0.50",
 		"@types/lz-string": "^1.3.34",
 		"@types/throttle-debounce": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -46,15 +46,14 @@
 		}
 	},
 	"dependencies": {
-		"@types/webextension-polyfill": "^0.8.3",
-		"webext-detect-page": "^4.0.0",
-		"webextension-polyfill": "^0.9.0"
+		"webext-detect-page": "^4.0.0"
 	},
 	"devDependencies": {
 		"@rollup/plugin-commonjs": "^21.0.1",
 		"@rollup/plugin-node-resolve": "^13.1.3",
 		"@rollup/plugin-typescript": "^8.3.0",
 		"@sindresorhus/tsconfig": "^2.0.0",
+		"@types/chrome": "0.0.176",
 		"@types/estree": "^0.0.50",
 		"@types/lz-string": "^1.3.34",
 		"@types/throttle-debounce": "^2.1.0",

--- a/readme.md
+++ b/readme.md
@@ -244,12 +244,12 @@ Default: `true`
 
 Whether info and warnings (on sync, updating form, etc.) should be logged to the console or not.
 
-###### storage
+###### storageType
 
-Type: `chrome.storage.StorageArea`
-Default: `chrome.storage.sync`
+Type: `'loacal' | 'sync' | 'managed'`
+Default: `sync`
 
-What storage area to use (sync storage vs local storage). Sync storage is used by default.
+What storage area type to use (sync storage vs local storage). Sync storage is used by default.
 
 #### optionsStorage.set(options)
 

--- a/readme.md
+++ b/readme.md
@@ -244,6 +244,13 @@ Default: `true`
 
 Whether info and warnings (on sync, updating form, etc.) should be logged to the console or not.
 
+###### storage
+
+Type: `chrome.storage.StorageArea`
+Default: `chrome.storage.sync`
+
+What storage area to use (sync storage vs local storage). Sync storage is used by default.
+
 #### optionsStorage.set(options)
 
 This will merge the existing options with the object provided.

--- a/readme.md
+++ b/readme.md
@@ -246,10 +246,16 @@ Whether info and warnings (on sync, updating form, etc.) should be logged to the
 
 ###### storageType
 
-Type: `'loacal' | 'sync' | 'managed'`
+Type: `'local' | 'sync'`
 Default: `sync`
 
 What storage area type to use (sync storage vs local storage). Sync storage is used by default.
+
+**Considerations for selecting which option to use:**
+
+- Sync is default as it's likely more convenient for users.
+- Firefox requires [`browser_specific_settings.gecko.id`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) for the `sync` storage to work locally.
+- Sync storage is subject to much tighter [quota limitations](https://developer.chrome.com/docs/extensions/reference/storage/#property-sync), and may cause privacy concerns if the data being stored is confidential. 
 
 #### optionsStorage.set(options)
 

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ const options = await optionsStorage.getAll();
 // {showStars: 10}
 ```
 
-**Note:** `OptionsSync` relies on `browser.storage.sync`, so its [limitations](https://developer.chrome.com/apps/storage#properties) apply, both the size limit and the type of data stored (which must be compatible with JSON).
+**Note:** `OptionsSync` relies on `chrome.storage.sync`, so its [limitations](https://developer.chrome.com/apps/storage#properties) apply, both the size limit and the type of data stored (which must be compatible with JSON).
 
 ### Advanced usage
 
@@ -148,7 +148,7 @@ optionsStorage.syncForm(document.querySelector('form'));
 
 When using the `syncForm` method, `OptionsSync` will serialize the form using [dom-form-serializer](https://github.com/jefersondaniel/dom-form-serializer), which uses the `name` attribute as `key` for your options. Refer to its readme for more info on the structure of the data.
 
-Any user changes to the form are automatically saved into `browser.storage.sync` after 300ms (debounced). It listens to `input` events.
+Any user changes to the form are automatically saved into `chrome.storage.sync` after 300ms (debounced). It listens to `input` events.
 
 #### Input validation
 
@@ -235,7 +235,7 @@ A list of functions to run in the `background` when the extension is updated. Ex
 Type: `string`
 Default: `'options'`
 
-The key used to store data in `browser.storage.sync`
+The key used to store data in `chrome.storage.sync`
 
 ###### logging
 
@@ -246,8 +246,8 @@ Whether info and warnings (on sync, updating form, etc.) should be logged to the
 
 ###### storage
 
-Type: `browser.Storage.StorageArea`
-Default: `browser.storage.sync`
+Type: `chrome.storage.StorageArea`
+Default: `chrome.storage.sync`
 
 What storage area to use (sync storage vs local storage). Sync storage is used by default.
 
@@ -275,7 +275,7 @@ This returns a Promise that will resolve with all the options.
 
 #### optionsStorage.syncForm(form)
 
-Any defaults or saved options will be loaded into the `<form>` and any change will automatically be saved via `browser.storage.sync`
+Any defaults or saved options will be loaded into the `<form>` and any change will automatically be saved via `chrome.storage.sync`
 
 ##### form
 

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ const options = await optionsStorage.getAll();
 // {showStars: 10}
 ```
 
-**Note:** `OptionsSync` relies on `chrome.storage.sync`, so its [limitations](https://developer.chrome.com/apps/storage#properties) apply, both the size limit and the type of data stored (which must be compatible with JSON).
+**Note:** `OptionsSync` relies on `browser.storage.sync`, so its [limitations](https://developer.chrome.com/apps/storage#properties) apply, both the size limit and the type of data stored (which must be compatible with JSON).
 
 ### Advanced usage
 
@@ -148,7 +148,7 @@ optionsStorage.syncForm(document.querySelector('form'));
 
 When using the `syncForm` method, `OptionsSync` will serialize the form using [dom-form-serializer](https://github.com/jefersondaniel/dom-form-serializer), which uses the `name` attribute as `key` for your options. Refer to its readme for more info on the structure of the data.
 
-Any user changes to the form are automatically saved into `chrome.storage.sync` after 300ms (debounced). It listens to `input` events.
+Any user changes to the form are automatically saved into `browser.storage.sync` after 300ms (debounced). It listens to `input` events.
 
 #### Input validation
 
@@ -235,7 +235,7 @@ A list of functions to run in the `background` when the extension is updated. Ex
 Type: `string`
 Default: `'options'`
 
-The key used to store data in `chrome.storage.sync`
+The key used to store data in `browser.storage.sync`
 
 ###### logging
 
@@ -246,8 +246,8 @@ Whether info and warnings (on sync, updating form, etc.) should be logged to the
 
 ###### storage
 
-Type: `chrome.storage.StorageArea`
-Default: `chrome.storage.sync`
+Type: `browser.Storage.StorageArea`
+Default: `browser.storage.sync`
 
 What storage area to use (sync storage vs local storage). Sync storage is used by default.
 
@@ -275,7 +275,7 @@ This returns a Promise that will resolve with all the options.
 
 #### optionsStorage.syncForm(form)
 
-Any defaults or saved options will be loaded into the `<form>` and any change will automatically be saved via `chrome.storage.sync`
+Any defaults or saved options will be loaded into the `<form>` and any change will automatically be saved via `browser.storage.sync`
 
 ##### form
 

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,7 @@ const defaultSetup = {
 	_migrations: {},
 	defaults: {},
 	storageName: 'options',
+	storageType: 'sync',
 };
 
 const simpleSetup = {
@@ -26,6 +27,7 @@ const simpleSetup = {
 		sound: true,
 	},
 	storageName: 'settings',
+	storageType: 'sync',
 };
 
 test.beforeEach(() => {


### PR DESCRIPTION
I use it in https://github.com/transclude-me/extension

Motivation: I started using this via template, but apparently the values for settings are too large to store remotely 😿 . I still like the interface/form sync aspects of this and so, substituting the storage area to be local storage seems like a good solution.  

Prior interest: #19 

---
Question/confusion I have here - this lib is using the the chrome* api*s and yet works with FF, and supplying `browser.storage.local` works for passing the stoarge area here, but presumably this has different apis (callback vs promise). How does interop work here?