### PR TITLE
Automatically reload options when the extension reloads

### DIFF
--- a/.github/workflows/esm-lint.yml
+++ b/.github/workflows/esm-lint.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/download-artifact@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16
       - run: echo "${{ env.IMPORT_TEXT }} '${{ env.NPM_MODULE_NAME }}'" > index.mjs
       - run: npm install ./artifact
       - run: node index.mjs

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import chromeP from 'webext-polyfill-kinda';
 import {isBackground} from 'webext-detect-page';
 import {serialize, deserialize} from 'dom-form-serializer/dist/dom-form-serializer.mjs';
 import LZString from 'lz-string';
+import {onContextInvalidated} from 'webext-events';
 import {loadFile, saveFile} from './file.js';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention -- CJS in ESM imports
@@ -182,6 +183,10 @@ class OptionsSync<UserOptions extends Options> {
 
 		this._form.querySelector('.js-export')?.addEventListener('click', this.exportToFile);
 		this._form.querySelector('.js-import')?.addEventListener('click', this.importFromFile);
+
+		onContextInvalidated.addListener(() => {
+			location.reload();
+		});
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"lz-string": "^1.4.4",
 		"throttle-debounce": "^5.0.0",
 		"webext-detect-page": "^4.0.1",
+		"webext-events": "^1.1.0",
 		"webext-polyfill-kinda": "^1.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
- Closes #66 
- Uses https://github.com/fregante/webext-events/pull/7

This just reloads the options page. There's no point in blocking the whole page or telling the user to take action.

 When the context is invalidated, no data is lost (thanks to `webext-options-sync`) other than maybe the UI state, but otherwise the only action to take is to reload the page as you can't save the UI state anyway.

---

I thought about just disabling the form, maybe even with something simple like:

```js
	onContextInvalidated.addListener(() => {
		const form = select('form')!;
		form.replaceChildren(
			<fieldset disabled>
				<legend>Refresh page to continue</legend>
				{[...form.childNodes]}
			</fieldset>,
		);
	});
```

which resulted in https://user-images.githubusercontent.com/1402241/236544446-121501b4-5cc5-4560-9085-cb7ff5e23262.mov

